### PR TITLE
Use plugin to create multi-release JAR with module info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <java.module.version>9</java.module.version>
   </properties>
 
   <dependencies>
@@ -108,6 +109,27 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+          <groupId>org.moditect</groupId>
+          <artifactId>moditect-maven-plugin</artifactId>
+          <version>1.0.0.Beta2</version>
+          <executions>
+              <execution>
+                  <id>add-module-infos</id>
+                  <phase>package</phase>
+                  <goals>
+                      <goal>add-module-info</goal>
+                  </goals>
+                  <configuration>
+                      <jvmVersion>${java.module.version}</jvmVersion>
+                      <overwriteExistingFiles>true</overwriteExistingFiles>
+                      <module>
+                          <moduleInfoFile>src/main/java9/module-info.java</moduleInfoFile>
+                      </module>
+                  </configuration>
+              </execution>
+          </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,6 +1,0 @@
-module io.fusionauth {
-  exports io.fusionauth.der;
-  exports io.fusionauth.jwks;
-  exports io.fusionauth.jwt;
-  exports io.fusionauth.pem;
-}

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,0 +1,17 @@
+module io.fusionauth {
+	exports io.fusionauth.jwt.hmac;
+	exports io.fusionauth.jwt.json;
+	exports io.fusionauth.pem.domain;
+	exports io.fusionauth.jwks.domain;
+	exports io.fusionauth.jwks;
+	exports io.fusionauth.der;
+	exports io.fusionauth.jwt.domain;
+	exports io.fusionauth.jwt.ec;
+	exports io.fusionauth.jwt.rsa;
+	exports io.fusionauth.jwt;
+	exports io.fusionauth.pem;
+
+	requires com.fasterxml.jackson.annotation;
+	requires com.fasterxml.jackson.core;
+	requires com.fasterxml.jackson.databind;
+}


### PR DESCRIPTION
Made Eclipse generate the module-info file. The added packages might be too much (?). 

But this is the least painful way to make a multi-release jar I've found so far. I have not verified that it works in an actual Java 11 project, that should be part of the (your) QA. Using the regular maven plugins resulted in a more complex solution since javadoc for Java 11 refused to work.
