### PR TITLE
Add support for JWK Thumbprint generation

### DIFF
--- a/src/main/java/io/fusionauth/jwt/JWTUtils.java
+++ b/src/main/java/io/fusionauth/jwt/JWTUtils.java
@@ -16,6 +16,7 @@
 
 package io.fusionauth.jwt;
 
+import io.fusionauth.jwks.domain.JSONWebKey;
 import io.fusionauth.jwt.domain.Header;
 import io.fusionauth.jwt.domain.JWT;
 import io.fusionauth.jwt.domain.KeyPair;
@@ -157,6 +158,40 @@ public class JWTUtils {
    */
   public static KeyPair generate521_ECKeyPair() {
     return generateKeyPair(521, KeyType.EC);
+  }
+
+  /**
+   * Generate the JWK Thumbprint as per RFC7638.
+   *
+   * @param algorithm the algorithm used to calculate the hash of the thumbprint, generally SHA-1 or SHA-256.
+   * @param key       the {@link JSONWebKey} to determine the thumbprint for
+   * @return the base64url-encoded JWK Thumbprint
+   */
+  public static String generateJWS_kid(String algorithm, JSONWebKey key) {
+    StringBuilder builder = new StringBuilder();
+    switch (key.kty) {
+      case EC:
+        builder.append("{\"crv\":\"");
+        builder.append(key.crv);
+        builder.append("\",\"kty\":\"");
+        builder.append(key.kty);
+        builder.append("\",\"x\":\"");
+        builder.append(key.x);
+        builder.append("\",\"y\":\"");
+        builder.append(key.y);
+        builder.append("\"}");
+        break;
+      case RSA:
+        builder.append("{\"e\":\"");
+        builder.append(key.e);
+        builder.append("\",\"kty\":\"");
+        builder.append(key.kty);
+        builder.append("\",\"n\":\"");
+        builder.append(key.n);
+        builder.append("\"}");
+        break;
+    }
+    return digest(algorithm, builder.toString().getBytes());
   }
 
   /**

--- a/src/test/java/io/fusionauth/jwt/JWTUtilsTest.java
+++ b/src/test/java/io/fusionauth/jwt/JWTUtilsTest.java
@@ -16,9 +16,11 @@
 
 package io.fusionauth.jwt;
 
+import io.fusionauth.jwks.domain.JSONWebKey;
 import io.fusionauth.jwt.domain.Algorithm;
 import io.fusionauth.jwt.domain.JWT;
 import io.fusionauth.jwt.domain.KeyPair;
+import io.fusionauth.jwt.domain.KeyType;
 import io.fusionauth.jwt.hmac.HMACSigner;
 import io.fusionauth.pem.domain.PEM;
 import org.testng.annotations.Test;
@@ -247,6 +249,26 @@ public class JWTUtilsTest {
     assertEquals(JWTUtils.convertThumbprintToFingerprint("vDT213a_AF5eRdElKZla9-9dpc8"), "BC34F6D776BF005E5E45D12529995AF7EF5DA5CF");
     // Convert x5t#256 --> HEX SHA-256 Fingerprint
     assertEquals(JWTUtils.convertThumbprintToFingerprint("tIFNLfPYY14sM0DLTp6T-BZ3yPaPUPKc8Hnh6evXTeM"), "B4814D2DF3D8635E2C3340CB4E9E93F81677C8F68F50F29CF079E1E9EBD74DE3");
+  }
+
+  @Test
+  public void jws_kid() {
+    JSONWebKey rsaKey = new JSONWebKey();
+    rsaKey.kty = KeyType.RSA;
+    rsaKey.n = "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw";
+    rsaKey.e = "AQAB";
+
+    assertEquals("nMGlFRw9Y5POaSOaIaRBc9P2nfA", JWTUtils.generateJWS_kid("SHA-1", rsaKey));
+    assertEquals("NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs", JWTUtils.generateJWS_kid("SHA-256", rsaKey));
+
+    JSONWebKey ecKey = new JSONWebKey();
+    ecKey.kty = KeyType.EC;
+    ecKey.crv = "P-256";
+    ecKey.x = "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4";
+    ecKey.y = "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM";
+
+    assertEquals("VHriznG7vJAFpXMXRmGgAkA5sEE", JWTUtils.generateJWS_kid("SHA-1", ecKey));
+    assertEquals("cn-I_WNMClehiVp51i_0VpOENW1upEerA8sEam5hn-s", JWTUtils.generateJWS_kid("SHA-256", ecKey));
   }
 
   private void assertPrefix(String key, String prefix) {


### PR DESCRIPTION
JSON Web Key Thumbprints are defined in [RFC7638] as a means to generate the
thumbprint of a JWK.

As a commonly used option for the `kid` on a JWK, we should support it
within this library.

Closes #18.

[RFC7638]: https://tools.ietf.org/html/rfc7638