### PR TITLE
Compare HMAC in a time constant manner to prevent timing attacks

### DIFF
--- a/src/main/java/io/fusionauth/jwt/hmac/HMACVerifier.java
+++ b/src/main/java/io/fusionauth/jwt/hmac/HMACVerifier.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -155,7 +156,7 @@ public class HMACVerifier implements Verifier {
       mac.init(new SecretKeySpec(secret, algorithm.getName()));
       byte[] actualSignature = mac.doFinal(message);
 
-      if (!Arrays.equals(signature, actualSignature)) {
+      if (!MessageDigest.isEqual(signature, actualSignature)) {
         throw new InvalidJWTSignatureException();
       }
     } catch (InvalidKeyException | NoSuchAlgorithmException e) {


### PR DESCRIPTION
Not comparing HMACs in a time constant manner, could allow an attacker
to use server response time as an oracle and with the help of statistical
analysis calculate the used secret.

Fixes: #17
