### PR TITLE
Modify datatype for typ Header

### DIFF
--- a/src/main/java/io/fusionauth/jwt/domain/Header.java
+++ b/src/main/java/io/fusionauth/jwt/domain/Header.java
@@ -39,7 +39,7 @@ public class Header {
   public Map<String, String> properties = new LinkedHashMap<>();
 
   @JsonProperty("typ")
-  public Type type = Type.JWT;
+  public String type = "JWT";
 
   public Header() {
   }


### PR DESCRIPTION
Hi,
I found several jwt with "typ" header other than "JWT" value. When I check to the RFC, I found out that the "typ" header is optional and can contain any words (although it is recommended to use "JWT"). That is why I change the datatype to String to accomodate the RFC.

Thanks,
