### PR TITLE
fix EdDSA thumbprint calculation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 FusionAuth JWT Changes
 
+Changes in 6.0.1
+ * Fix EdDSA thumbprint calculation
+
 Changes in 6.0.0
  * Move to Java 17 LTS as the minimum requirement.
  * Remove CryptoProvider and just use JCE to use a third party provider such as BouncyCastle.

--- a/build.savant
+++ b/build.savant
@@ -17,7 +17,7 @@
 jacksonVersion = "2.15.4"
 slf4jVersion = "1.7.36"
 
-project(group: "io.fusionauth", name: "fusionauth-jwt", version: "6.0.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-jwt", version: "6.0.1", licenses: ["ApacheV2_0"]) {
 
   workflow {
     fetch {

--- a/src/main/java/io/fusionauth/jwt/JWTUtils.java
+++ b/src/main/java/io/fusionauth/jwt/JWTUtils.java
@@ -20,6 +20,7 @@ import io.fusionauth.jwks.domain.JSONWebKey;
 import io.fusionauth.jwt.domain.Header;
 import io.fusionauth.jwt.domain.JWT;
 import io.fusionauth.jwt.domain.KeyPair;
+import io.fusionauth.jwt.domain.KeyType;
 import io.fusionauth.jwt.json.Mapper;
 import io.fusionauth.pem.domain.PEM;
 
@@ -32,8 +33,6 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-
-import static io.fusionauth.jwt.domain.KeyType.EC;
 
 /**
  * Helper to generate new HMAC secrets, EC and RSA public / private key pairs and other fun things.
@@ -213,6 +212,7 @@ public class JWTUtils {
 
   /**
    * Generate the JWK Thumbprint as per RFC 7638.
+   * EdDSA thumbprint per RFC 8037
    *
    * @param algorithm the algorithm used to calculate the hash of the thumbprint, generally SHA-1 or SHA-256.
    * @param key       the {@link JSONWebKey} to determine the thumbprint for
@@ -221,15 +221,26 @@ public class JWTUtils {
   public static String generateJWS_kid(String algorithm, JSONWebKey key) {
     Map<String, Object> thumbPrint = new LinkedHashMap<>(4);
 
-    if (key.kty == EC) {
-      thumbPrint.put("crv", key.crv);
-      thumbPrint.put("kty", key.kty);
-      thumbPrint.put("x", key.x);
-      thumbPrint.put("y", key.y);
-    } else {
-      thumbPrint.put("e", key.e);
-      thumbPrint.put("kty", key.kty);
-      thumbPrint.put("n", key.n);
+    switch (key.kty) {
+      case EC:
+        thumbPrint.put("crv", key.crv);
+        thumbPrint.put("kty", key.kty);
+        thumbPrint.put("x", key.x);
+        thumbPrint.put("y", key.y);
+        break;
+      case RSA:
+      case RSASSA_PSS:
+        thumbPrint.put("e", key.e);
+        thumbPrint.put("kty", key.kty);
+        thumbPrint.put("n", key.n);
+        break;
+      case OKP:
+        thumbPrint.put("crv", key.crv);
+        thumbPrint.put("kty", key.kty);
+        thumbPrint.put("x", key.x);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported key type [" + key.kty + "]");
     }
 
     return digest(algorithm, Mapper.serialize(thumbPrint));

--- a/src/test/java/io/fusionauth/jwt/JWTUtilsTest.java
+++ b/src/test/java/io/fusionauth/jwt/JWTUtilsTest.java
@@ -384,6 +384,24 @@ public class JWTUtilsTest extends BaseTest {
   }
 
   @Test
+  public void jws_kid_pssControl() {
+    // Same elements as rsa control, but we have a different key type,
+    // so we'll get different sha values.
+    JSONWebKey pssKey = new JSONWebKey();
+    pssKey.kty = KeyType.RSASSA_PSS;
+    pssKey.n = "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw";
+    pssKey.e = "AQAB";
+
+    // SHA-1
+    assertEquals(JWTUtils.generateJWS_kid(pssKey), "cQP8OQaKDsN3IcB7kS48XMywclQ");
+    assertEquals(JWTUtils.generateJWS_kid("SHA-1", pssKey), "cQP8OQaKDsN3IcB7kS48XMywclQ");
+
+    // SHA-256
+    assertEquals(JWTUtils.generateJWS_kid_S256(pssKey), "BAQAQh9ReyFN-FTuSC_vWqCvGb7Bdn3apRpnnT-BtRw");
+    assertEquals(JWTUtils.generateJWS_kid("SHA-256", pssKey), "BAQAQh9ReyFN-FTuSC_vWqCvGb7Bdn3apRpnnT-BtRw");
+  }
+
+  @Test
   public void jws_kid_ec() {
     JSONWebKey ecKey = new JSONWebKey();
     ecKey.kty = KeyType.EC;
@@ -398,6 +416,24 @@ public class JWTUtilsTest extends BaseTest {
     // SHA-256
     assertEquals(JWTUtils.generateJWS_kid_S256(ecKey), "cn-I_WNMClehiVp51i_0VpOENW1upEerA8sEam5hn-s");
     assertEquals(JWTUtils.generateJWS_kid("SHA-256", ecKey), "cn-I_WNMClehiVp51i_0VpOENW1upEerA8sEam5hn-s");
+  }
+
+  @Test
+  public void jws_kid_eddsa() {
+    // Control example from RFC 8037 (the SHA-256 thumbprint)
+    // https://www.rfc-editor.org/rfc/rfc8037.html#appendix-A.3
+    JSONWebKey eddsaKey = new JSONWebKey();
+    eddsaKey.kty = KeyType.OKP;
+    eddsaKey.crv = "Ed25519";
+    eddsaKey.x = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo";
+
+    // SHA-1
+    assertEquals(JWTUtils.generateJWS_kid(eddsaKey), "VmxEWEmFxGLRPOX30HXyts0yJOE");
+    assertEquals(JWTUtils.generateJWS_kid("SHA-1", eddsaKey), "VmxEWEmFxGLRPOX30HXyts0yJOE");
+
+    // SHA-256
+    assertEquals(JWTUtils.generateJWS_kid_S256(eddsaKey), "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k");
+    assertEquals(JWTUtils.generateJWS_kid("SHA-256", eddsaKey), "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k");
   }
 
   private void assertPrefix(String key, String prefix) {


### PR DESCRIPTION
### Problem:
The logic in `generateJWS_kid()` wasn't considering EdDSA keys (type OKP).

### Solution:
Use a switch statement to better catch future key types and logic for EdDSA thumbprint. Add tests.
